### PR TITLE
Add blacklist management module

### DIFF
--- a/Blacklists.cs
+++ b/Blacklists.cs
@@ -1,0 +1,175 @@
+using DSharpPlus;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using DSharpPlus.Interactivity;
+using MongoDB.Driver;
+using RoWifi_Alpha.Attributes;
+using RoWifi_Alpha.Exceptions;
+using RoWifi_Alpha.Models;
+using RoWifi_Alpha.Services;
+using RoWifi_Alpha.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RoWifi_Alpha.Commands
+{
+    [Group("blacklists"), Aliases("blacklist", "bl")]
+    [RequireBotPermissions(Permissions.EmbedLinks | Permissions.AddReactions), RequireGuild, RequireRoWifiAdmin]
+    [Description("Module to blacklist users from a server")]
+    public class Blacklists : BaseCommandModule
+    {
+        public DatabaseService Database { get; set; }
+        public RobloxService Roblox { get; set; }
+        public LoggerService Logger { get; set; }
+
+        [GroupCommand]
+        [Description("View users blacklisted from the server")]
+        public async Task GroupCommand(CommandContext Context)
+        {
+            var interactivity = Context.Client.GetInteractivity();
+            RoGuild guild = await Database.GetGuild(Context.Guild.Id);
+            if (guild == null)
+                throw new CommandException("Blacklist Viewing Failed", "Server was not setup. Please ask the server owner to set up this server.");
+            if (guild.Blacklists == null || guild.Blacklists.Count == 0)
+                throw new CommandException("Blacklist Viewing Failed", "There are no blacklists associated with this server");
+
+            List<Page> pages = new List<Page>();
+            var BlacklistList = guild.Blacklists.Select((x, i) => new { Index = i, Value = x }).GroupBy(x => x.Index / 12).Select(x => x.Select(v => v.Value).ToList());
+            int Page = 1;
+
+            foreach (List<RoBlacklist> blacklists in BlacklistList)
+            {
+                DiscordEmbedBuilder embed = Miscellanous.GetDefaultEmbed();
+                embed.WithTitle("Blacklists").WithDescription($"Page {Page}");
+                foreach (RoBlacklist blacklist in blacklists)
+                {
+                    if (blacklist.Type == BlacklistType.Name)
+                        embed.AddField($"Id: {blacklist.Id}", $"Type: Id\nReason: {blacklist.Reason}", true);
+                    else if (blacklist.Type == BlacklistType.Group)
+                        embed.AddField($"Id: {blacklist.Id}", $"Type: Group\nReason: {blacklist.Reason}", true);
+                    else if (blacklist.Type == BlacklistType.Custom)
+                        embed.AddField($"Code: {blacklist.Id}", $"Type: Custom\nReason: {blacklist.Reason}", true);
+                }
+                pages.Add(new Page(embed: embed));
+                Page++;
+            }
+            if (Page == 2)
+                await Context.RespondAsync(embed: pages[0].Embed);
+            else
+                await interactivity.SendPaginatedMessageAsync(Context.Channel, Context.User, pages);
+        }
+
+        [Command("name"), RequireGuild, RequireRoWifiAdmin]
+        [Description("Command to blacklist a user from Roblox Username")]
+        public async Task BlacklistNameAsync(CommandContext Context, [Description("The Roblox Username of the user to blacklist")] string Name,
+            [RemainingText, Description("The reason to blacklist the user for")] string Reason = "")
+        {
+            RoGuild guild = await Database.GetGuild(Context.Guild.Id);
+            if (guild == null)
+                throw new CommandException("Blacklist Addition Failed", "Server was not setup. Please ask the server owner to set up this server.");
+
+            int? RobloxId = await Roblox.GetIdFromUsername(Name);
+            if (RobloxId == null)
+                throw new CommandException("Blacklist Addition Failed", "There was no Roblox Id found associated with this name");
+            if (Reason.Length == 0)
+                Reason = "N/A";
+
+            RoBlacklist blacklist = new RoBlacklist(RobloxId.ToString(), Reason, BlacklistType.Name);
+            UpdateDefinition<RoGuild> update = Builders<RoGuild>.Update.Push(g => g.Blacklists, blacklist);
+            await Database.ModifyGuild(Context.Guild.Id, update);
+            DiscordEmbedBuilder embed = Miscellanous.GetDefaultEmbed();
+            embed.WithColor(DiscordColor.Green).WithTitle("Blacklist Addition Successful")
+                .AddField($"Id: {blacklist.Id}", $"Type: Id\nReason: {blacklist.Reason}");
+            await Context.RespondAsync(embed: embed.Build());
+            await Logger.LogAction(Context.Guild, Context.User, "Blacklist Addition", $"Id: {blacklist.Id}", $"Type: Id\nReason: {blacklist.Reason}");
+        }
+
+        [Command("group"), RequireGuild, RequireRoWifiAdmin]
+        [Description("Command to blacklist an entire group")]
+        public async Task BlacklistGroupAsync(CommandContext Context, [Description("The Id of the Roblox group to blacklist")]int Id,
+            [RemainingText, Description("The reason to blacklist the group for")] string Reason = "")
+        {
+            RoGuild guild = await Database.GetGuild(Context.Guild.Id);
+            if (guild == null)
+                throw new CommandException("Blacklist Addition Failed", "Server was not setup. Please ask the server owner to set up this server.");
+            if (Reason.Length == 0)
+                Reason = "N/A";
+
+            RoBlacklist blacklist = new RoBlacklist(Id.ToString(), Reason, BlacklistType.Group);
+            UpdateDefinition<RoGuild> update = Builders<RoGuild>.Update.Push(g => g.Blacklists, blacklist);
+            await Database.ModifyGuild(Context.Guild.Id, update);
+            DiscordEmbedBuilder embed = Miscellanous.GetDefaultEmbed();
+            embed.WithColor(DiscordColor.Green).WithTitle("Blacklist Addition Successful")
+                .AddField($"Id: {blacklist.Id}", $"Type: Group\nReason: {blacklist.Reason}");
+            await Context.RespondAsync(embed: embed.Build());
+            await Logger.LogAction(Context.Guild, Context.User, "Blacklist Addition", $"Id: {blacklist.Id}", $"Type: Group\nReason: {blacklist.Reason}");
+        }
+
+        [Command("custom"), RequireGuild, RequireRoWifiAdmin]
+        [Description("Command to create your own blacklists")]
+        public async Task BlacklistCustomAsync(CommandContext Context, [RemainingText, Description("The custom code to define the blacklist")] string Code = "")
+        {
+            if (Code.Length == 0)
+                throw new CommandException("Blacklist Addition Failed", "The blacklist code should not empty");
+            var interactivity = Context.Client.GetInteractivity();
+            RoUser user = await Database.GetUserAsync(Context.User.Id);
+            if (user == null)
+                throw new CommandException("Blacklist Addition Failed", "You must be verified to use this feature");
+            RoGuild guild = await Database.GetGuild(Context.Guild.Id);
+            if (guild == null)
+                throw new CommandException("Blacklist Addition Failed", "Server was not setup. Please ask the server owner to set up this server.");
+
+            try
+            {
+                RoCommand cmd = new RoCommand(Code);
+                Dictionary<int, int> Ranks = await Roblox.GetUserRoles(user.RobloxId);
+                string Username = await Roblox.GetUsernameFromId(user.RobloxId);
+                RoCommandUser CommandUser = new RoCommandUser(user, Context.Member, Ranks, Username);
+                cmd.Evaluate(CommandUser);
+            }
+            catch (Exception e)
+            {
+                throw new CommandException("Blacklist Addition Failed", $"Command Error: {e.Message}");
+            }
+
+            await Context.RespondAsync("Enter the reason of this blacklist.\nSay `cancel` if you wish to cancel this command");
+            var response = await interactivity.WaitForMessageAsync(xm => xm.Author.Id == Context.User.Id);
+            if (response.TimedOut || response.Result.Content.Equals("cancel", StringComparison.OrdinalIgnoreCase))
+                throw new CommandException("Blacklist Addition Failed", "Command has been cancelled");
+            string Reason = response.Result.Content;
+
+            RoBlacklist blacklist = new RoBlacklist(Code, Reason, BlacklistType.Custom);
+            UpdateDefinition<RoGuild> update = Builders<RoGuild>.Update.Push(g => g.Blacklists, blacklist);
+            await Database.ModifyGuild(Context.Guild.Id, update);
+            DiscordEmbedBuilder embed = Miscellanous.GetDefaultEmbed();
+            embed.WithColor(DiscordColor.Green).WithTitle("Bind Addition Successful")
+                .AddField($"Id: {blacklist.Id}", $"Type: Custom\nReason: {blacklist.Reason}");
+            await Context.RespondAsync(embed: embed.Build());
+            await Logger.LogAction(Context.Guild, Context.User, "Blacklist Addition", $"Id: {blacklist.Id}", $"Type: Custom\nReason: {blacklist.Reason}");
+        }
+
+        [Command("remove"), RequireGuild, RequireRoWifiAdmin]
+        [Description("Command to remove a blacklist"), Aliases("delete")]
+        public async Task BlacklistDeleteAsync(CommandContext Context, [RemainingText, Description("The Id of the assigned blacklist")] string Id)
+        {
+            RoGuild guild = await Database.GetGuild(Context.Guild.Id);
+            if (guild == null)
+                throw new CommandException("Blacklist Removal Failed", "Server was not setup. Please ask the server owner to set up this server.");
+            if (guild.Blacklists == null || guild.Blacklists.Count == 0)
+                throw new CommandException("Blacklist Removal Failed", "There are no blacklists associated with this server");
+            RoBlacklist blacklist = guild.Blacklists.Where(b => b.Id == Id).FirstOrDefault();
+            if (blacklist == null)
+                throw new CommandException("Blacklist Removal Failed", "There was no blacklist found associated with the given Id");
+            UpdateDefinition<RoGuild> update = Builders<RoGuild>.Update.Pull(g => g.Blacklists, blacklist);
+            await Database.ModifyGuild(Context.Guild.Id, update);
+            DiscordEmbedBuilder embed = Miscellanous.GetDefaultEmbed();
+            embed.WithColor(DiscordColor.Green).WithTitle("Blacklist Removal Successful").WithDescription($"The blacklist with Id {Id} was successfully deleted");
+            await Context.RespondAsync(embed: embed.Build());
+            await Logger.LogAction(Context.Guild, Context.User, "Blacklist Deletion", $"Id: {blacklist.Id}", $"Reason: {blacklist.Reason}");
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# chat1234
+# RoWifi Alpha Modules
+
+This repository contains sample modules for a Roblox verification bot built with **DSharpPlus** and examples in **Python** using `discord.py`.
+
+## Available Modules
+
+- `Blacklists.cs` – Provides commands to manage user, group, and custom blacklists within a guild.
+- `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands (`/verify`, `/update`). Verification codes are delivered in DMs and responses use ephemeral messages where possible.
+
+## Building
+
+These files are provided as examples and are not part of a complete project. To compile `Blacklists.cs`, integrate the module into your existing DSharpPlus bot project. For `bot.py`, install `discord.py` and `aiohttp` and run the script with `python bot.py` after setting the `DISCORD_BOT_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains sample modules for a Roblox verification bot built with
 
 - `Blacklists.cs` – Provides commands to manage user, group, and custom blacklists within a guild.
 - `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands
-(`/verify`, `/update`). Verification codes arrive in embeds and include a helper button, with ephemeral channel responses when DMs are blocked.
+(`/verify`, `/update`). Verification codes are delivered in embeds with a helper button using ephemeral channel responses instead of DMs.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # RoWifi Alpha Modules
 
-This repository contains sample modules for a Roblox verification bot built with **DSharpPlus** and examples in **Python** using
- `discord.py`.
+This repository contains sample modules for a Roblox verification bot built with **DSharpPlus** and examples in **Python** using `discord.py`.
 
 ## Available Modules
 
 - `Blacklists.cs` – Provides commands to manage user, group, and custom blacklists within a guild.
-- `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands
-(`/verify`, `/update`). Verification codes are delivered in embeds with a helper button using ephemeral channel responses instead of DMs, keeping the codes hidden from other users even for prefix commands.
+- `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands (`/verify`, `/update`). The bot tries to send verification codes by DM and falls back to an ephemeral embed in the channel when DMs are blocked. A helper button links to the Roblox site, and `/update` refreshes roles after the code is placed in the profile.
 
 ## Building
 
-These files are provided as examples and are not part of a complete project. To compile `Blacklists.cs`, integrate the module in
-to your existing DSharpPlus bot project. For `bot.py`, install `discord.py` and `aiohttp` and run the script with `python bot.py`
- after setting the `DISCORD_BOT_TOKEN` environment variable.
+These files are provided as examples and are not part of a complete project. To compile `Blacklists.cs`, integrate the module into your existing DSharpPlus bot project.
+
+## Running the sample bot
+
+1. Install requirements: `pip install discord.py aiohttp`
+2. Set the `DISCORD_BOT_TOKEN` environment variable with your bot token.
+3. Run the script with `python bot.py`.
+4. Use `!verify <RobloxUser>` or `/verify roblox_username:<RobloxUser>` to receive a verification code.
+5. Add the code to the Roblox profile description and run `!update` or `/update` to receive the `Verified` role.
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains sample modules for a Roblox verification bot built with
 
 - `Blacklists.cs` – Provides commands to manage user, group, and custom blacklists within a guild.
 - `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands
-(`/verify`, `/update`). Verification codes are delivered in embeds with a helper button using ephemeral channel responses instead of DMs.
+(`/verify`, `/update`). Verification codes are delivered in embeds with a helper button using ephemeral channel responses instead of DMs, keeping the codes hidden from other users even for prefix commands.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # RoWifi Alpha Modules
 
-This repository contains sample modules for a Roblox verification bot built with **DSharpPlus** and examples in **Python** using `discord.py`.
+This repository contains sample modules for a Roblox verification bot built with **DSharpPlus** and examples in **Python** using
+ `discord.py`.
 
 ## Available Modules
 
 - `Blacklists.cs` – Provides commands to manage user, group, and custom blacklists within a guild.
-- `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands (`/verify`, `/update`). Verification codes are delivered in DMs and responses use ephemeral messages where possible.
+- `bot.py` – Stand‑alone script demonstrating Roblox verification via prefix commands (`!verify`, `!update`) and slash commands
+(`/verify`, `/update`). Verification codes arrive in embeds and include a helper button, with ephemeral channel responses when DMs are blocked.
 
 ## Building
 
-These files are provided as examples and are not part of a complete project. To compile `Blacklists.cs`, integrate the module into your existing DSharpPlus bot project. For `bot.py`, install `discord.py` and `aiohttp` and run the script with `python bot.py` after setting the `DISCORD_BOT_TOKEN` environment variable.
+These files are provided as examples and are not part of a complete project. To compile `Blacklists.cs`, integrate the module in
+to your existing DSharpPlus bot project. For `bot.py`, install `discord.py` and `aiohttp` and run the script with `python bot.py`
+ after setting the `DISCORD_BOT_TOKEN` environment variable.

--- a/bot.py
+++ b/bot.py
@@ -76,7 +76,7 @@ async def verify(ctx, roblox_username: str):
         color=discord.Color.blurple(),
     )
     embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-    await ctx.reply(embed=embed, mention_author=False, view=VerifyView())
+    await ctx.reply(embed=embed, mention_author=False, view=VerifyView(), ephemeral=True)
 
 
 @bot.command()
@@ -84,7 +84,7 @@ async def update(ctx):
     success, msg = await update_roles(ctx.author)
     color = discord.Color.green() if success else discord.Color.red()
     embed = discord.Embed(description=msg, color=color)
-    await ctx.reply(embed=embed, mention_author=False)
+    await ctx.reply(embed=embed, mention_author=False, ephemeral=True)
 
 
 @bot.tree.command(name="verify", description="로블록스 인증 시작")

--- a/bot.py
+++ b/bot.py
@@ -40,10 +40,24 @@ async def get_roblox_description(username: str) -> str:
             return profile.get("description", "")
 
 
-async def start_verification(user: discord.User, roblox_username: str) -> str:
+async def start_verification(user: discord.User, roblox_username: str) -> discord.Embed | None:
     code = str(random.randint(100000, 999999))
     pending_codes[user.id] = {"roblox_user": roblox_username, "code": code}
-    return code
+
+    embed = discord.Embed(
+        title="Roblox Verification",
+        description=(
+            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `!update` 또는 `/update` 명령을 실행하세요."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+
+    try:
+        await user.send(embed=embed, view=VerifyView())
+        return None
+    except discord.Forbidden:
+        return embed
 
 
 async def update_roles(member: discord.Member):
@@ -67,16 +81,11 @@ async def update_roles(member: discord.Member):
 
 @bot.command()
 async def verify(ctx, roblox_username: str):
-    code = await start_verification(ctx.author, roblox_username)
-    embed = discord.Embed(
-        title="Roblox Verification",
-        description=(
-            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `!update` 또는 `/update` 명령을 실행하세요."
-        ),
-        color=discord.Color.blurple(),
-    )
-    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-    await ctx.reply(embed=embed, mention_author=False, view=VerifyView(), ephemeral=True)
+    embed = await start_verification(ctx.author, roblox_username)
+    if embed:
+        await ctx.reply(embed=embed, mention_author=False, view=VerifyView(), ephemeral=True)
+    else:
+        await ctx.reply("DM을 확인해주세요!", mention_author=False, ephemeral=True)
 
 
 @bot.command()
@@ -90,16 +99,11 @@ async def update(ctx):
 @bot.tree.command(name="verify", description="로블록스 인증 시작")
 @app_commands.describe(roblox_username="로블록스 사용자명")
 async def slash_verify(interaction: discord.Interaction, roblox_username: str):
-    code = await start_verification(interaction.user, roblox_username)
-    embed = discord.Embed(
-        title="Roblox Verification",
-        description=(
-            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `/update` 명령을 실행하세요."
-        ),
-        color=discord.Color.blurple(),
-    )
-    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-    await interaction.response.send_message(embed=embed, ephemeral=True, view=VerifyView())
+    embed = await start_verification(interaction.user, roblox_username)
+    if embed:
+        await interaction.response.send_message(embed=embed, ephemeral=True, view=VerifyView())
+    else:
+        await interaction.response.send_message("DM을 확인해주세요!", ephemeral=True)
 
 
 @bot.tree.command(name="update", description="인증된 역할 갱신")

--- a/bot.py
+++ b/bot.py
@@ -43,19 +43,7 @@ async def get_roblox_description(username: str) -> str:
 async def start_verification(user: discord.User, roblox_username: str) -> str:
     code = str(random.randint(100000, 999999))
     pending_codes[user.id] = {"roblox_user": roblox_username, "code": code}
-    embed = discord.Embed(
-        title="Roblox Verification",
-        description=(
-            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `/update` 또는 `!update` 명령을 실행하세요."
-        ),
-        color=discord.Color.blurple(),
-    )
-    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-    try:
-        await user.send(embed=embed, view=VerifyView())
-        return ""
-    except discord.Forbidden:
-        return code
+    return code
 
 
 async def update_roles(member: discord.Member):
@@ -80,19 +68,15 @@ async def update_roles(member: discord.Member):
 @bot.command()
 async def verify(ctx, roblox_username: str):
     code = await start_verification(ctx.author, roblox_username)
-    if code:
-        embed = discord.Embed(
-            title="DM 차단 감지",
-            description=(
-                "DM을 보낼 수 없어 여기서 인증 코드를 안내합니다.\n"
-                f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가 후 `!update` 또는 `/update`를 사용하세요."
-            ),
-            color=discord.Color.orange(),
-        )
-        embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-        await ctx.reply(embed=embed, mention_author=False, view=VerifyView())
-    else:
-        await ctx.reply("DM을 확인해주세요!", mention_author=False, view=VerifyView())
+    embed = discord.Embed(
+        title="Roblox Verification",
+        description=(
+            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `!update` 또는 `/update` 명령을 실행하세요."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+    await ctx.reply(embed=embed, mention_author=False, view=VerifyView())
 
 
 @bot.command()
@@ -107,19 +91,15 @@ async def update(ctx):
 @app_commands.describe(roblox_username="로블록스 사용자명")
 async def slash_verify(interaction: discord.Interaction, roblox_username: str):
     code = await start_verification(interaction.user, roblox_username)
-    if code:
-        embed = discord.Embed(
-            title="DM 차단 감지",
-            description=(
-                "DM을 보낼 수 없어 여기서 인증 코드를 안내합니다.\n"
-                f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가 후 `/update` 명령을 사용하세요."
-            ),
-            color=discord.Color.orange(),
-        )
-        embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
-        await interaction.response.send_message(embed=embed, ephemeral=True, view=VerifyView())
-    else:
-        await interaction.response.send_message("DM을 확인해주세요!", ephemeral=True, view=VerifyView())
+    embed = discord.Embed(
+        title="Roblox Verification",
+        description=(
+            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `/update` 명령을 실행하세요."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+    await interaction.response.send_message(embed=embed, ephemeral=True, view=VerifyView())
 
 
 @bot.tree.command(name="update", description="인증된 역할 갱신")

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,87 @@
+import os
+import random
+import aiohttp
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+
+intents = discord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+pending_codes = {}
+
+async def get_roblox_description(username: str) -> str:
+    url = f"https://api.roblox.com/users/get-by-username?username={username}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            data = await resp.json()
+            user_id = data.get("Id")
+            if not user_id:
+                return ""
+        url = f"https://users.roblox.com/v1/users/{user_id}"
+        async with session.get(url) as resp:
+            profile = await resp.json()
+            return profile.get("description", "")
+
+async def start_verification(user: discord.User, roblox_username: str):
+    code = str(random.randint(100000, 999999))
+    pending_codes[user.id] = {"roblox_user": roblox_username, "code": code}
+    await user.send(
+        f"로블록스 계정 인증을 위해 아래 코드를 {roblox_username} 프로필 소개란에 추가한 뒤 `/update` 또는 `!update` 명령을 실행하세요.\n"
+        f"인증 코드: `{code}`"
+    )
+
+async def update_roles(member: discord.Member):
+    data = pending_codes.get(member.id)
+    if not data:
+        await member.send("먼저 `/verify` 또는 `!verify`로 코드를 발급받으세요.")
+        return
+
+    roblox_user = data["roblox_user"]
+    code = data["code"]
+    description = await get_roblox_description(roblox_user)
+
+    if code in description:
+        role = discord.utils.get(member.guild.roles, name="Verified")
+        if role:
+            await member.add_roles(role)
+        await member.send(f"인증 성공! 로블록스 계정: {roblox_user}")
+        pending_codes.pop(member.id, None)
+    else:
+        await member.send("프로필에서 코드를 찾을 수 없습니다. 다시 시도해주세요.")
+
+@bot.command()
+async def verify(ctx, roblox_username: str):
+    await start_verification(ctx.author, roblox_username)
+    await ctx.send(f"{ctx.author.mention} DM을 확인해주세요!")
+
+@bot.command()
+async def update(ctx):
+    await update_roles(ctx.author)
+    await ctx.send(f"{ctx.author.mention} 인증 확인을 시도했습니다. DM을 확인하세요.")
+
+@bot.tree.command(name="verify", description="로블록스 인증 시작")
+@app_commands.describe(roblox_username="로블록스 사용자명")
+async def slash_verify(interaction: discord.Interaction, roblox_username: str):
+    await start_verification(interaction.user, roblox_username)
+    await interaction.response.send_message("DM을 확인해주세요!", ephemeral=True)
+
+@bot.tree.command(name="update", description="인증된 역할 갱신")
+async def slash_update(interaction: discord.Interaction):
+    if not interaction.guild:
+        await interaction.response.send_message("서버 내에서 실행해주세요.", ephemeral=True)
+        return
+    member = interaction.guild.get_member(interaction.user.id)
+    await update_roles(member)
+    await interaction.response.send_message("인증 확인을 시도했습니다. DM을 확인하세요.", ephemeral=True)
+
+@bot.event
+async def on_ready():
+    await bot.tree.sync()
+    print(f"Logged in as {bot.user}")
+
+if __name__ == "__main__":
+    bot.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,19 @@ bot = commands.Bot(command_prefix="!", intents=intents)
 
 pending_codes = {}
 
+
+class VerifyView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+        self.add_item(
+            discord.ui.Button(
+                label="프로필 수정 방법",
+                url="https://www.roblox.com/",
+                style=discord.ButtonStyle.link,
+            )
+        )
+
+
 async def get_roblox_description(username: str) -> str:
     url = f"https://api.roblox.com/users/get-by-username?username={username}"
     async with aiohttp.ClientSession() as session:
@@ -26,19 +39,29 @@ async def get_roblox_description(username: str) -> str:
             profile = await resp.json()
             return profile.get("description", "")
 
-async def start_verification(user: discord.User, roblox_username: str):
+
+async def start_verification(user: discord.User, roblox_username: str) -> str:
     code = str(random.randint(100000, 999999))
     pending_codes[user.id] = {"roblox_user": roblox_username, "code": code}
-    await user.send(
-        f"로블록스 계정 인증을 위해 아래 코드를 {roblox_username} 프로필 소개란에 추가한 뒤 `/update` 또는 `!update` 명령을 실행하세요.\n"
-        f"인증 코드: `{code}`"
+    embed = discord.Embed(
+        title="Roblox Verification",
+        description=(
+            f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가한 뒤 `/update` 또는 `!update` 명령을 실행하세요."
+        ),
+        color=discord.Color.blurple(),
     )
+    embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+    try:
+        await user.send(embed=embed, view=VerifyView())
+        return ""
+    except discord.Forbidden:
+        return code
+
 
 async def update_roles(member: discord.Member):
     data = pending_codes.get(member.id)
     if not data:
-        await member.send("먼저 `/verify` 또는 `!verify`로 코드를 발급받으세요.")
-        return
+        return False, "먼저 `/verify` 또는 `!verify`로 코드를 발급받으세요."
 
     roblox_user = data["roblox_user"]
     code = data["code"]
@@ -48,26 +71,56 @@ async def update_roles(member: discord.Member):
         role = discord.utils.get(member.guild.roles, name="Verified")
         if role:
             await member.add_roles(role)
-        await member.send(f"인증 성공! 로블록스 계정: {roblox_user}")
         pending_codes.pop(member.id, None)
+        return True, f"인증 성공! 로블록스 계정: {roblox_user}"
     else:
-        await member.send("프로필에서 코드를 찾을 수 없습니다. 다시 시도해주세요.")
+        return False, "프로필에서 코드를 찾을 수 없습니다. 다시 시도해주세요."
+
 
 @bot.command()
 async def verify(ctx, roblox_username: str):
-    await start_verification(ctx.author, roblox_username)
-    await ctx.send(f"{ctx.author.mention} DM을 확인해주세요!")
+    code = await start_verification(ctx.author, roblox_username)
+    if code:
+        embed = discord.Embed(
+            title="DM 차단 감지",
+            description=(
+                "DM을 보낼 수 없어 여기서 인증 코드를 안내합니다.\n"
+                f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가 후 `!update` 또는 `/update`를 사용하세요."
+            ),
+            color=discord.Color.orange(),
+        )
+        embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+        await ctx.reply(embed=embed, mention_author=False, view=VerifyView())
+    else:
+        await ctx.reply("DM을 확인해주세요!", mention_author=False, view=VerifyView())
+
 
 @bot.command()
 async def update(ctx):
-    await update_roles(ctx.author)
-    await ctx.send(f"{ctx.author.mention} 인증 확인을 시도했습니다. DM을 확인하세요.")
+    success, msg = await update_roles(ctx.author)
+    color = discord.Color.green() if success else discord.Color.red()
+    embed = discord.Embed(description=msg, color=color)
+    await ctx.reply(embed=embed, mention_author=False)
+
 
 @bot.tree.command(name="verify", description="로블록스 인증 시작")
 @app_commands.describe(roblox_username="로블록스 사용자명")
 async def slash_verify(interaction: discord.Interaction, roblox_username: str):
-    await start_verification(interaction.user, roblox_username)
-    await interaction.response.send_message("DM을 확인해주세요!", ephemeral=True)
+    code = await start_verification(interaction.user, roblox_username)
+    if code:
+        embed = discord.Embed(
+            title="DM 차단 감지",
+            description=(
+                "DM을 보낼 수 없어 여기서 인증 코드를 안내합니다.\n"
+                f"`{roblox_username}` 프로필 소개란에 아래 코드를 추가 후 `/update` 명령을 사용하세요."
+            ),
+            color=discord.Color.orange(),
+        )
+        embed.add_field(name="인증 코드", value=f"`{code}`", inline=False)
+        await interaction.response.send_message(embed=embed, ephemeral=True, view=VerifyView())
+    else:
+        await interaction.response.send_message("DM을 확인해주세요!", ephemeral=True, view=VerifyView())
+
 
 @bot.tree.command(name="update", description="인증된 역할 갱신")
 async def slash_update(interaction: discord.Interaction):
@@ -75,13 +128,17 @@ async def slash_update(interaction: discord.Interaction):
         await interaction.response.send_message("서버 내에서 실행해주세요.", ephemeral=True)
         return
     member = interaction.guild.get_member(interaction.user.id)
-    await update_roles(member)
-    await interaction.response.send_message("인증 확인을 시도했습니다. DM을 확인하세요.", ephemeral=True)
+    success, msg = await update_roles(member)
+    color = discord.Color.green() if success else discord.Color.red()
+    embed = discord.Embed(description=msg, color=color)
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
 
 @bot.event
 async def on_ready():
     await bot.tree.sync()
     print(f"Logged in as {bot.user}")
+
 
 if __name__ == "__main__":
     bot.run(TOKEN)


### PR DESCRIPTION
## Summary
- add Blacklists.cs module for user/group/custom blacklists
- document blacklist module in README
- add Python verification script with prefix and slash commands

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_688e6ce18ee4833284f368fa1552167a